### PR TITLE
Added vserver_info

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_gather_facts.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_gather_facts.py
@@ -60,7 +60,8 @@ ontap_facts:
             "lun_info": {...},
             "storage_failover_info": {...},
             "vserver_login_banner_info": {...},
-            "vserver_motd_info": {...}
+            "vserver_motd_info": {...},
+            "vserver_info": {...}
     }'
 '''
 
@@ -231,6 +232,12 @@ class NetAppGatherFacts(object):
             'security-key-manager-key-get-iter',
             attribute='security-key-manager-key-info',
             field=('node', 'key-id'),
+            query={'max-records': '1024'}
+        )
+        self.netapp_info['vserver_info'] = self.get_generic_get_iter(
+            'vserver-get-iter',
+            attribute='vserver-info',
+            field='vserver-name',
             query={'max-records': '1024'}
         )
 


### PR DESCRIPTION
Get vserver information

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added verserver_info to geth information about available vservers
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
na_ontap_gather_facts
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/centos/ansible2.6/lib/python2.7/site-packages/ansible
  executable location = /home/centos/ansible2.6/bin/ansible
  python version = 2.7.5 (default, Jul 13 2018, 13:06:57) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
